### PR TITLE
Add namedtuple to perf test

### DIFF
--- a/perf.py
+++ b/perf.py
@@ -22,6 +22,10 @@ class C{n}:
             return NotImplemented
 '''
 
+namedtuple_template = '''
+C{n} = namedtuple('C{n}', ['a', 'b', 'c', 'd', 'e'])
+'''
+
 dataclass_template = '''
 @dataclass
 class C{n}:
@@ -81,6 +85,10 @@ def write_perftemp(count, template, setup):
 def main(reps):
     write_perftemp(100, standard_template, '')
     run_test('standard classes', reps)
+
+    write_perftemp(100, namedtuple_template, 'from collections import namedtuple\n')
+    run_test('namedtuple', reps)
+
     write_perftemp(100, dataclass_template, 'from dataclasses import dataclass\n')
     run_test('dataclasses', reps)
     try:


### PR DESCRIPTION
In case anyone else is curious too.

Results on my machine:

$ python perf.py
standard classes 0.20907020568847656
namedtuple 0.6940827369689941
dataclasses 3.169813871383667
attrs 4.215808153152466
cluegen 0.21304893493652344
cluegen_eval 1.668367862701416
